### PR TITLE
feat: Sync Back Enhanced Provider - CSR Support + Configurable Timeouts

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,12 +9,36 @@ default: build
 build: fmtcheck
 	go install
 
+# Build binary locally for installation
+build-local: fmtcheck
+	go build -o $(PLUGIN_NAME)
+
 # Install to the legacy plugin path for local testing/development
-local-install: build
+local-install: build-local
 	@echo "Installing provider to ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)"
 	@mkdir -p ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)
 	@cp $(PLUGIN_NAME) ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)
 	@echo "Local install complete! Legacy plugin path: ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)"
+
+# Install to the modern plugin path for Terraform 0.13+
+local-install-modern: build-local
+	$(eval OS_ARCH := $(shell go env GOOS)_$(shell go env GOARCH))
+	@echo "Installing provider to ~/.terraform.d/plugins/registry.terraform.io/camptocamp/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)/$(PLUGIN_NAME)_v$(PLUGIN_VERSION)"
+	@mkdir -p ~/.terraform.d/plugins/registry.terraform.io/camptocamp/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)
+	@cp $(PLUGIN_NAME) ~/.terraform.d/plugins/registry.terraform.io/camptocamp/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)/$(PLUGIN_NAME)_v$(PLUGIN_VERSION)
+	@echo "Modern install complete! Plugin path: ~/.terraform.d/plugins/registry.terraform.io/camptocamp/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)/$(PLUGIN_NAME)_v$(PLUGIN_VERSION)"
+
+# Install to the local development path (matches local/puppetca/puppetca source)
+local-install-dev: build-local
+	$(eval OS_ARCH := $(shell go env GOOS)_$(shell go env GOARCH))
+	@echo "Installing provider to ~/.terraform.d/plugins/local/puppetca/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)/$(PLUGIN_NAME)"
+	@mkdir -p ~/.terraform.d/plugins/local/puppetca/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)
+	@cp $(PLUGIN_NAME) ~/.terraform.d/plugins/local/puppetca/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)/$(PLUGIN_NAME)
+	@echo "Development install complete! Plugin path: ~/.terraform.d/plugins/local/puppetca/puppetca/$(PLUGIN_VERSION)/$(OS_ARCH)/$(PLUGIN_NAME)"
+
+# Install to all plugin paths (legacy, modern, and development)
+install-local: local-install local-install-modern local-install-dev
+	@echo "Provider installed to legacy, modern, and development plugin paths"
 
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
@@ -24,7 +48,7 @@ testacc: fmtcheck
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."
-	gofmt -s -w ./$(PKG_NAME)
+	gofmt -s -w $(GOFMT_FILES)
 
 # Currently required by tf-deploy compile
 fmtcheck:
@@ -49,4 +73,4 @@ vendor:
 vet:
 	go vet $<
 
-.PHONY: build test testacc fmt fmtcheck lint test-compile vendor
+.PHONY: build build-local test testacc fmt fmtcheck lint test-compile vendor local-install local-install-modern local-install-dev install-local

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,11 +1,20 @@
 TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=puppetca
+PLUGIN_NAME=terraform-provider-puppetca
+PLUGIN_VERSION=1.0.0
 
 default: build
 
 build: fmtcheck
 	go install
+
+# Install to the legacy plugin path for local testing/development
+local-install: build
+	@echo "Installing provider to ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)"
+	@mkdir -p ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)
+	@cp $(PLUGIN_NAME) ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)
+	@echo "Local install complete! Legacy plugin path: ~/.terraform.d/plugins/puppetca_v$(PLUGIN_VERSION)/$(PLUGIN_NAME)"
 
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4

--- a/README.md
+++ b/README.md
@@ -52,12 +52,39 @@ resource "puppetca_certificate" "ec2instance" {
   name   = "0a7842c26ad1.foo.com"
   usedby = aws_instance.ec2instance.id
 }
+
+# Example: Passing a CSR to the Puppet CA
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "example" {
+  private_key_pem = tls_private_key.example.private_key_pem
+
+  subject {
+    common_name  = "foo.example.com"
+    organization = "Example Org"
+  }
+}
+
+resource "puppetca_certificate" "csr_example" {
+  name = "foo.example.com"
+  csr  = tls_cert_request.example.cert_request_pem
+  sign = true
+}
 ```
 
 The first `puppetca_certificate` resource, `test`, will remove the certificate if a destroy plan is run.
 The second `puppetca_certificate` resource, `ec2instance`, will remove the certificate if Terraform destroys the EC2 instance.
 
 The `usedby` parameter can be populated as a resource parameter to drive the removal of the certificate from the Puppet CA at the desired time.  In the example above, if a Terraform plan has to recreate the EC2 instance, the certificate will be removed when the EC2 instance is destroyed since each EC2 instance is assigned a new instance id.
+
+The `csr` parameter allows you to pass a Certificate Signing Request (CSR) to the Puppet CA. In the example above:
+- A private key is generated using the `tls_private_key` resource.
+- A CSR is created using the `tls_cert_request` resource.
+- The CSR is passed to the `puppetca_certificate` resource using the `csr` attribute.
+- The `sign` parameter ensures the certificate is signed automatically after submission.
 
 The provider can also be configured using environment variables:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ resource "puppetca_certificate" "csr_example" {
   name = "foo.example.com"
   csr  = tls_cert_request.example.cert_request_pem
   sign = true
+
+  timeouts {
+    create = "60m"
+    update = "30m"
+    delete = "10m"
+  }
 }
 
 resource "vm_provider" "vm" {
@@ -96,6 +102,31 @@ The `csr` parameter allows you to pass a Certificate Signing Request (CSR) to th
 - A CSR is created using the `tls_cert_request` resource.
 - The CSR is passed to the `puppetca_certificate` resource using the `csr` attribute.
 - The `sign` parameter ensures the certificate is signed automatically after submission.
+
+## Timeouts
+
+**New in v1.0.0:** The provider now supports configurable timeouts for certificate operations to prevent hanging operations.
+
+```hcl
+resource "puppetca_certificate" "example" {
+  name = "example-node"
+  env  = "production"
+  sign = true
+
+  timeouts {
+    create = "60m"  # Default: 20m
+    update = "30m"  # Default: 20m
+    delete = "10m"  # Default: 20m
+  }
+}
+```
+
+Timeout values can be specified in:
+- `s` for seconds
+- `m` for minutes  
+- `h` for hours
+
+If no timeout is specified, operations default to 20 minutes. This prevents certificate operations from hanging indefinitely when the Puppet CA is slow or unresponsive.
 
 The provider can also be configured using environment variables:
 
@@ -157,14 +188,32 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 $ make testacc
 ```
 
-In order to test the code locally, you can use `make local-install` to deploy the generated provider.
+## Local Development and Installation
+
+For local development and testing, you can use the following make targets:
+
+```sh
+# Install to development path (recommended for local testing)
+$ make local-install-dev
+
+# Install to legacy path
+$ make local-install
+
+# Install to modern registry path
+$ make local-install-modern
+
+# Install to all paths
+$ make install-local
+```
+
+After installation, use the provider in your Terraform configuration:
 
 ```hcl
 terraform {
   required_providers {
     puppetca = {
       source  = "local/puppetca/puppetca"
-      version = "0.1.0"
+      version = "1.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
@@ -202,5 +251,11 @@ resource "tls_cert_request" "example" {
 resource "puppetca_certificate" "csr_example" {
   name = local.FQDN
   csr  = tls_cert_request.example.cert_request_pem
+
+  timeouts {
+    create = "45m"
+    update = "20m"
+    delete = "5m"
+  }
 }
 ```

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -23,6 +23,22 @@ output "cert" {
 }
 ```
 
+### Using Timeouts
+
+```hcl
+resource "puppetca_certificate" "mycert" {
+  name = "myhost.example.com"
+  csr  = file("myhost.csr")
+  sign = true
+
+  timeouts {
+    create = "60m"
+    update = "30m"
+    delete = "10m"
+  }
+}
+```
+
 ## Argument Reference
 
 - `name` (String, Required): The node name for the certificate.
@@ -30,6 +46,12 @@ output "cert" {
 - `sign` (Bool, Optional): Whether to sign the certificate after CSR submission. Defaults to `false`.
 - `env` (String, Optional): Puppet environment name.
 - `usedby` (String, Optional): An optional string to indicate who or what uses this certificate.
+
+### Timeouts
+
+- `create` (String, Optional): Timeout for certificate creation operations. Defaults to `20m`.
+- `update` (String, Optional): Timeout for certificate update operations. Defaults to `20m`.
+- `delete` (String, Optional): Timeout for certificate deletion operations. Defaults to `20m`.
 
 ## Attribute Reference
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -1,0 +1,49 @@
+# Resource: puppetca_certificate
+
+Manages Puppet CA certificates.  
+**New in v1.0.0:** You can now submit a Certificate Signing Request (CSR) directly from Terraform.
+
+## Example Usage
+
+### Submit and Sign a CSR
+
+```hcl
+resource "puppetca_certificate" "mycert" {
+  name = "myhost.example.com"
+  csr  = file("myhost.csr")
+  sign = true
+}
+```
+
+### Retrieve a Signed Certificate
+
+```hcl
+output "cert" {
+  value = puppetca_certificate.mycert.cert
+}
+```
+
+## Argument Reference
+
+- `name` (String, Required): The node name for the certificate.
+- `csr` (String, Optional): The PEM-encoded CSR to submit to the Puppet CA. If omitted, the provider will only attempt to retrieve or sign an existing CSR.
+- `sign` (Bool, Optional): Whether to sign the certificate after CSR submission. Defaults to `false`.
+- `env` (String, Optional): Puppet environment name.
+- `usedby` (String, Optional): An optional string to indicate who or what uses this certificate.
+
+## Attribute Reference
+
+- `cert` (String): The signed certificate in PEM format.
+
+## Import
+
+Import is supported using:
+
+```
+terraform import puppetca_certificate.example "nodename,environment"
+```
+
+## Notes
+
+- The `csr` field must contain a valid PEM-encoded CSR. Use `file("path/to/file.csr")` to load from disk.
+- If `sign` is `true`, the provider will attempt to sign the submitted CSR after submission.

--- a/examples/certificate_with_timeouts.tf
+++ b/examples/certificate_with_timeouts.tf
@@ -1,0 +1,24 @@
+resource "puppetca_certificate" "example" {
+  name = "example-node"
+  env  = "production"
+  sign = true
+
+  timeouts {
+    create = "60m"
+    update = "30m"
+    delete = "10m"
+  }
+}
+
+# Example with CSR
+resource "puppetca_certificate" "example_with_csr" {
+  name = "example-node-csr"
+  env  = "production"
+  csr  = file("path/to/certificate.csr")
+
+  timeouts {
+    create = "45m"
+    update = "20m"
+    delete = "5m"
+  }
+} 

--- a/examples/terraform_config_with_timeouts.tf
+++ b/examples/terraform_config_with_timeouts.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    puppetca = {
+      source  = "local/puppetca/puppetca"
+      version = "1.0.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.1"
+    }
+  }
+}
+
+provider "puppetca" {
+  # Configure your provider settings here
+  # url = "https://your-puppet-ca-server"
+}
+
+resource "puppetca_certificate" "example" {
+  name = "example-node"
+  env  = "production"
+  sign = true
+
+  timeouts {
+    create = "60m"
+    update = "30m"
+    delete = "10m"
+  }
+}
+
+# Example with CSR
+resource "puppetca_certificate" "example_with_csr" {
+  name = "example-node-csr"
+  env  = "production"
+  csr  = file("path/to/certificate.csr")
+
+  timeouts {
+    create = "45m"
+    update = "20m"
+    delete = "5m"
+  }
+} 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/camptocamp/go-puppetca v0.0.0-20220207140217-c3faf5528998
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/terraform-plugin-framework v1.4.2 h1:P7a7VP1GZbjc4rv921Xy5OckzhoiO3ig6SGxwelD2sI=
 github.com/hashicorp/terraform-plugin-framework v1.4.2/go.mod h1:GWl3InPFZi2wVQmdVnINPKys09s9mLmTZr95/ngLnbY=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.0 h1:9buCmO0ciBITSCuw5ag6RdOwSsnBMl7OxOKOyXvRiZM=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.0/go.mod h1:kW0Wl17bODmZyj+Fiz9dNk1MXjPB+qG3wAs2d++J9w4=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=
 github.com/hashicorp/terraform-plugin-go v0.19.0/go.mod h1:EhRSkEPNoylLQntYsk5KrDHTZJh9HQoumZXbOGOXmec=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=


### PR DESCRIPTION
# 🔄 Sync Back: Enhanced Puppet CA Provider - CSR Support + Configurable Timeouts

This PR syncs back the enhanced Puppet CA provider from `halradaideh/master` to the upstream `camptocamp/terraform-provider-puppetca` repository.

## 🚀 Major Enhancements

This comprehensive update introduces two major features that significantly improve the provider's capabilities:

### 🔐 Certificate Signing Request (CSR) Support
- ✅ Added `csr` attribute to `puppetca_certificate` resource
- ✅ Support for PEM-encoded CSR submission to Puppet CA
- ✅ Validation to prevent conflicting `sign` and `csr` usage
- ✅ New `submitCSR` function for CSR handling
- ✅ Seamless integration with existing certificate workflows

### ⏱️ Configurable Timeouts (NEW)
- ✅ Added `terraform-plugin-framework-timeouts` dependency
- ✅ Implemented timeouts for create, update, and delete operations
- ✅ Default timeout of 20 minutes for all operations
- ✅ Configurable per-operation timeout settings
- ✅ Prevents hanging operations when Puppet CA is slow/unresponsive

### 🔧 Development & Build Improvements
- ✅ Enhanced Makefile with multiple installation targets
- ✅ Fixed `local-install` target for proper local development
- ✅ Added `local-install-dev` for development path installation
- ✅ Added `local-install-modern` for Terraform 0.13+ compatibility
- ✅ Added `install-local` to install to all plugin paths
- ✅ Fixed `fmt` target to use correct file paths

### 📚 Documentation & Examples
- ✅ Comprehensive README updates with both CSR and timeout examples
- ✅ New `docs/resources/certificate.md` with complete resource documentation
- ✅ Added example configurations for various use cases
- ✅ Installation instructions for local development

## 🎯 Usage Examples

### CSR Submission with Timeouts
```hcl
resource "tls_private_key" "example" {
  algorithm = "RSA"
  rsa_bits  = 2048
}

resource "tls_cert_request" "example" {
  private_key_pem = tls_private_key.example.private_key_pem
  subject {
    common_name  = "foo.example.com"
    organization = "Example Org"
  }
}

resource "puppetca_certificate" "csr_example" {
  name = "foo.example.com"
  csr  = tls_cert_request.example.cert_request_pem
  sign = true

  timeouts {
    create = "60m"
    update = "30m"
    delete = "10m"
  }
}
```

### Simple Certificate with Timeouts
```hcl
resource "puppetca_certificate" "example" {
  name = "example-node"
  env  = "production"
  sign = true

  timeouts {
    create = "45m"
    update = "20m"
    delete = "5m"
  }
}
```

## 🔧 Local Development

```bash
# Recommended for local testing
make local-install-dev

# Install to all plugin paths
make install-local

# Individual installations
make local-install        # Legacy path
make local-install-modern # Modern registry path
```

## ⚠️ Breaking Changes

- **Provider version updated to 1.0.0**
- Users need to update their Terraform configuration:
  ```hcl
  terraform {
    required_providers {
      puppetca = {
        source  = "camptocamp/puppetca"
        version = "1.0.0"  # Updated from previous versions
      }
    }
  }
  ```

## ✅ Testing & Validation

- ✅ Code compiles successfully with all new features
- ✅ Provider installs correctly to all plugin paths
- ✅ Terraform validates both CSR and timeout configurations
- ✅ All Makefile targets work as expected
- ✅ CSR submission and signing workflows tested
- ✅ Timeout functionality prevents hanging operations

## 🎉 Benefits

### CSR Support Benefits:
- Direct CSR submission from Terraform configurations
- Seamless integration with TLS provider for key/CSR generation
- Automated certificate signing workflows
- Better certificate lifecycle management

### Timeout Benefits:
- Prevents certificate operations from hanging indefinitely
- Configurable timeouts for different environments and requirements
- Better error handling and user experience
- Follows standard Terraform timeout conventions

## 🔄 Migration Guide

For existing users:
1. Update provider version to `1.0.0` in your Terraform configuration
2. Run `terraform init -upgrade` to get the new provider version
3. Optionally add timeout blocks to your certificate resources
4. Use the new CSR functionality if needed

## 📦 Files Changed

- `internal/resources/certificate.go` - Core CSR and timeout implementation
- `go.mod` & `go.sum` - Added timeouts dependency
- `GNUmakefile` - Enhanced installation targets and fixes
- `README.md` - Comprehensive documentation updates
- `docs/resources/certificate.md` - Complete resource documentation
- `examples/` - Added example configurations

## 🏷️ Version Information

This sync brings the provider to **version 1.0.0** with significant enhancements while maintaining backward compatibility for existing functionality.

---

**Note**: This PR replaces the previous PR #23 with a cleaner branch structure for better workflow management. 